### PR TITLE
Bugfix HI-98 version install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ Installs and configures a simple Redis service
 ----------------
 
 ```
+
+# Vars
+
+# False values install the default version fetched by APT
+# Note - that you may need to do some dependency resolution on your own in this case
+redis_version: false
+redis_listen_port: 6379
+redis_bind_interface: '0.0.0.0'
+
 #   requirements.yml
 #
 #   Example

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
 
+# False values install the default version fetched by APT
+# Note - that you may need to do some dependency resolution on your own in this case
+redis_version: false
 redis_listen_port: 6379
 redis_bind_interface: '0.0.0.0'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Install redis-server
   become: yes
   apt:
-    name: redis-server=2:3.0.6-1
+    name: "redis-server{% if redis_version %}={{ redis_version }}{% endif %}"
     state: present
   tags:
     - redis


### PR DESCRIPTION
This PR will

- fix #1 

For now at least, let's not be responsible for dependencies required by specific version and distribution installations.

We don't want to deal with something like this -

```
TASK [redis : Install redis-server] ***********************************************************************************
fatal: [data.dev.wf.com]: FAILED! => {"cache_update_time": 1549554006, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'redis-server=2:3.0.6-1'' failed: E: Unable to correct problems, you have held broken packages.\n", "rc": 100, "stderr": "E: Unable to correct problems, you have held broken packages.\n", "stderr_lines": ["E: Unable to correct problems, you have held broken packages."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n redis-server : Depends: redis-tools (= 2:3.0.6-1) but 2:3.0.6-1ubuntu0.3 is to be installed\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Some packages could not be installed. This may mean that you have", "requested an impossible situation or if you are using the unstable", "distribution that some required packages have not yet been created", "or been moved out of Incoming.", "The following information may help to resolve the situation:", "", "The following packages have unmet dependencies:", " redis-server : Depends: redis-tools (= 2:3.0.6-1) but 2:3.0.6-1ubuntu0.3 is to be installed"]}
```